### PR TITLE
Prevent worker logs when debug mode is disabled

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -25,10 +25,12 @@ Module.onRuntimeInitialized = () => {
 }
 
 self.out = function (text) {
-  if (text === 'libass: No usable fontconfig configuration file found, using fallback.') {
-    console.debug(text)
-  } else {
-    console.log(text)
+  if (self.debug) {
+    if (text === 'libass: No usable fontconfig configuration file found, using fallback.') {
+      console.debug(text)
+    } else {
+      console.log(text)
+    }
   }
 }
 self.err = function (text) {


### PR DESCRIPTION
I don't know if this is the only place where this check should be put in place, but I was still getting debug log spam from the worker with debug mode disabled.

![image](https://user-images.githubusercontent.com/25076630/205536340-5144d01e-1a3d-4e60-acb2-0a5e5ef17756.png)
