### PR TITLE
fix: useLocalFonts - find all of same family

### DIFF
--- a/src/jassub.js
+++ b/src/jassub.js
@@ -567,8 +567,8 @@ export default class JASSUB extends EventTarget {
     try {
       // @ts-ignore
       queryLocalFonts().then(fontData => {
-        const font = fontData?.find(obj => obj.fullName.toLowerCase() === name)
-        if (font) {
+        const fonts = fontData?.filter(obj => obj.family.toLowerCase() === name)
+        for (const font of fonts) {
           font.blob().then(blob => {
             blob.arrayBuffer().then(buffer => {
               this.addFont(new Uint8Array(buffer))


### PR DESCRIPTION
Refs #55 

This PR tries to illustrate the problem in #55. It might not be the "correct" solution to the problem (although it solves my immediate issue), so feel free to take over or discard it.

The proposed fix it to find local fonts by _family name_ instead of _name_, then provide all found. I guess ideally we would like to find only e.g. Arial Bold, but then more information is needed about which font is wanted.